### PR TITLE
fix(cli): Defer mkdir until actual copy loop

### DIFF
--- a/bin/kw-doc-cli.js
+++ b/bin/kw-doc-cli.js
@@ -112,7 +112,6 @@ if (configuration.copy) {
       src: path.join(basePath, item.src),
       dest: path.join(basePath, item.dest),
     });
-    shell.mkdir('-p', path.join(basePath, item.dest));
   });
 }
 
@@ -123,6 +122,7 @@ if (configuration.copy) {
 while (copyPool.length) {
   var srcDest = copyPool.shift();
   console.log(' - copy: ', srcDest.src, 'to', srcDest.dest);
+  shell.mkdir('-p', srcDest.dest);
   shell.cp('-rf', srcDest.src, srcDest.dest);
 }
 


### PR DESCRIPTION
This allows for copying files to a new name. Should address https://github.com/Kitware/paraview-glance/issues/348. The underlying issue is that `app/index.html` and `nightly/index.html` are being created as *folders*, which shouldn't be happening.

This change will slightly change the semantics of how kw-doc does copy: instead of creating all folders prior to performing any copy, create the folders as they are needed. Since now `index.html` gets copied prior to the mkdir call (in Glance's `config.js`), this should fix the issue.

I'm still not 100% sure what changed to make this an issue now of all times, as I cannot seem to replicate the original working builds.