### PR TITLE
fix(template): Update packages

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,16 +14,16 @@
   },
   "dependencies": {
     "cheerio": "^0.20.0",
-    "hexo": "^3.2.0",
-    "hexo-deployer-git": "^0.1.0",
-    "hexo-generator-archive": "^0.1.4",
-    "hexo-generator-feed": "^1.1.0",
-    "hexo-generator-sitemap": "^1.1.2",
-    "hexo-renderer-jade": "^0.3.0",
-    "hexo-renderer-marked": "^0.2.10",
-    "hexo-renderer-stylus": "^0.3.1",
-    "hexo-server": "^0.2.0",
-    "lodash": "^4.5.1",
-    "lunr": "^0.6.0"
+    "hexo": "^5.4.0",
+    "hexo-deployer-git": "^3.0.0",
+    "hexo-generator-archive": "^1.0.0",
+    "hexo-generator-feed": "^3.0.0",
+    "hexo-generator-sitemap": "^2.1.0",
+    "hexo-renderer-jade": "^0.5.0",
+    "hexo-renderer-marked": "^4.0.0",
+    "hexo-renderer-stylus": "^2.0.1",
+    "hexo-server": "^2.0.0",
+    "lodash": "^4.17.21",
+    "lunr": "^2.3.9"
   }
 }


### PR DESCRIPTION
Should fix https://github.com/Kitware/vtk-js/issues/1831. These dependencies are terribly out of date, which is likely causing some consternation for npm's dependency resolution. Though whether it is intended or an actual npm bug remains to be seen.